### PR TITLE
fix(ci): handle empty ids case to avoid panics

### DIFF
--- a/test/test_suite.go
+++ b/test/test_suite.go
@@ -42,7 +42,9 @@ func BasicDATest(t *testing.T, da da.DA) {
 	expID1 := make([]byte, 8)
 	binary.BigEndian.PutUint32(expID1, 42)
 
+	assert.GreaterOrEqual(t, len(id1), 1)
 	assert.Equal(t, id1[0], expID1)
+	assert.GreaterOrEqual(t, len(proof1), 1)
 	assert.Equal(t, proof1[0], []byte("mocked_transaction_hash"))
 
 	id2, proof2, err := da.Submit([]Blob{msg2})
@@ -51,7 +53,9 @@ func BasicDATest(t *testing.T, da da.DA) {
 	expID2 := make([]byte, 8)
 	binary.BigEndian.PutUint32(expID2, 43)
 
+	assert.GreaterOrEqual(t, len(id2), 1)
 	assert.Equal(t, id2[0], expID2)
+	assert.GreaterOrEqual(t, len(proof2), 1)
 	assert.Equal(t, proof2[0], []byte("mocked_transaction_hash2"))
 
 	ret, err := da.Get(id1)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Resolve panic seen in CI
```
--> Running unit tests
=== RUN   TestAvailDA
=== RUN   TestAvailDA/Basic_DA_test
    test_suite.go:40: 
        	Error Trace:	/home/runner/work/avail-da/avail-da/test/test_suite.go:40
        	            				/home/runner/work/avail-da/avail-da/test/test_suite.go:16
        	Error:      	Received unexpected error:
        	            	Post "http://localhost:9000/v2/submit": dial tcp [::1]:9000: connect: connection refused
        	Test:       	TestAvailDA/Basic_DA_test
--- FAIL: TestAvailDA (0.00s)
    --- FAIL: TestAvailDA/Basic_DA_test (0.00s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 34 [running]:
testing.tRunner.func1.2({0x94ad80, 0xc0001ac030})
	/opt/hostedtoolcache/go/1.21.6/x64/src/testing/testing.go:1545 +0x3f7
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.21.6/x64/src/testing/testing.go:1548 +0x716
panic({0x94ad80?, 0xc0001ac030?})
	/opt/hostedtoolcache/go/1.21.6/x64/src/runtime/panic.go:920 +0x270
github.com/rollkit/avail-da/test.BasicDATest(0xc000057e80?, {0xa20070, 0xc00006ac00})
	/home/runner/work/avail-da/avail-da/test/test_suite.go:45 +0xd79
github.com/rollkit/avail-da/test.RunDATestSuite.func1(0x0?)
	/home/runner/work/avail-da/avail-da/test/test_suite.go:16 +0x45
testing.tRunner(0xc00019a000, 0xc000180000)
	/opt/hostedtoolcache/go/1.21.6/x64/src/testing/testing.go:1595 +0x262
created by testing.(*T).Run in goroutine 6
	/opt/hostedtoolcache/go/1.21.6/x64/src/testing/testing.go:1648 +0x846
FAIL	github.com/rollkit/avail-da	0.019s
?   	github.com/rollkit/avail-da/cmd/avail-da	[no test files]
Mock Server is running on :9000
```

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Tests**
	- Enhanced test suite with additional assertions to verify the lengths of specific identifiers and their proofs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->