### PR TITLE
feat(da): support go-da v0.4.0

### DIFF
--- a/avail.go
+++ b/avail.go
@@ -77,13 +77,13 @@ func NewAvailDA(config Config, ctx context.Context) *AvailDA {
 var _ da.DA = &AvailDA{}
 
 // MaxBlobSize returns the max blob size
-func (c *AvailDA) MaxBlobSize() (uint64, error) {
+func (c *AvailDA) MaxBlobSize(ctx context.Context) (uint64, error) {
 	var maxBlobSize uint64 = 64 * 64 * 500
 	return maxBlobSize, nil
 }
 
 // Submit each blob to avail data availability layer
-func (c *AvailDA) Submit(daBlobs []da.Blob) ([]da.ID, []da.Proof, error) {
+func (c *AvailDA) Submit(ctx context.Context, daBlobs []da.Blob, gasPrice float64, namespace da.Namespace) ([]da.ID, error) {
 	resultChan := make(chan SubmitResponse, len(daBlobs))
 	errorChan := make(chan error, len(daBlobs))
 
@@ -156,24 +156,22 @@ func (c *AvailDA) Submit(daBlobs []da.Blob) ([]da.ID, []da.Proof, error) {
 
 	// Collect results from channels
 	var ids []da.ID
-	var proofs []da.Proof
 
 	for result := range resultChan {
 		ids = append(ids, makeID(result.BlockNumber))
-		proofs = append(proofs, makeProofs(result.TransactionHash))
 	}
 
 	// Check for errors
 	if err := <-errorChan; err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	fmt.Println("successfully submitted blobs to avail")
-	return ids, proofs, nil
+	return ids, nil
 }
 
 // Get returns Blob for each given ID, or an error
-func (c *AvailDA) Get(ids []da.ID) ([]da.Blob, error) {
+func (c *AvailDA) Get(ctx context.Context, ids []da.ID, namespace da.Namespace) ([]da.Blob, error) {
 	var blobs [][]byte
 	var blockNumber uint32
 	for _, id := range ids {
@@ -224,7 +222,7 @@ func (c *AvailDA) Get(ids []da.ID) ([]da.Blob, error) {
 }
 
 // GetIDs returns the ID
-func (c *AvailDA) GetIDs(height uint64) ([]da.ID, error) {
+func (c *AvailDA) GetIDs(ctx context.Context, height uint64, namespace da.Namespace) ([]da.ID, error) {
 	// todo:currently returning height as ID, need to extend avail-light api
 	heightAsUint32 := uint32(height)
 	ids := make([]byte, 8)
@@ -232,13 +230,23 @@ func (c *AvailDA) GetIDs(height uint64) ([]da.ID, error) {
 	return [][]byte{ids}, nil
 }
 
+// GetProofs returns inclusion Proofs for Blobs specified by their IDs.
+func (c *AvailDA) GetProofs(ctx context.Context, ids []da.ID, namespace da.Namespace) ([]da.Proof, error) {
+	// TODO: add transaction hash to ID, so we can use it for proofs here
+	var proofs []da.Proof
+	for _, id := range ids {
+		proofs = append(proofs, makeProofs(string(id)))
+	}
+	return proofs, nil
+}
+
 // Commit creates a Commitment for each given Blob.
-func (c *AvailDA) Commit(daBlobs []da.Blob) ([]da.Commitment, error) {
+func (c *AvailDA) Commit(ctx context.Context, daBlobs []da.Blob, namespace da.Namespace) ([]da.Commitment, error) {
 	return nil, nil
 }
 
 // Validate validates Commitments against the corresponding Proofs
-func (c *AvailDA) Validate(ids []da.ID, daProofs []da.Proof) ([]bool, error) {
+func (c *AvailDA) Validate(ctx context.Context, ids []da.ID, daProofs []da.Proof, namespace da.Namespace) ([]bool, error) {
 	return nil, nil
 }
 

--- a/cmd/avail-da/main.go
+++ b/cmd/avail-da/main.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/rollkit/avail-da"
-	"github.com/rollkit/go-da/proxy"
+	"github.com/rollkit/go-da/proxy-grpc"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.5
 
 require (
 	github.com/rollkit/go-da v0.0.0-20231207150926-93600f28d67d
-	github.com/stretchr/testify v1.8.4
+	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.61.0
 )
 
@@ -22,3 +22,5 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/rollkit/go-da => github.com/rollkit/go-da v0.4.1-0.20240313122451-9f38d3f26cb5

--- a/go.sum
+++ b/go.sum
@@ -12,10 +12,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rollkit/go-da v0.0.0-20231207150926-93600f28d67d h1:VeAbAkj+1+9OMc80BMIt7TokIAJudJrqI/59gTpMeuI=
-github.com/rollkit/go-da v0.0.0-20231207150926-93600f28d67d/go.mod h1:cy1LA9kCyCJHgszKkTh9hJn816l5Oa87GMA2c1imfqA=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/rollkit/go-da v0.4.1-0.20240313122451-9f38d3f26cb5 h1:wtvMngwt2BSgFNgi6iz6RrcpIhFHbvlM+29kaGZaGWI=
+github.com/rollkit/go-da v0.4.1-0.20240313122451-9f38d3f26cb5/go.mod h1:VsUeAoPvKl4Y8wWguu/VibscYiFFePkkrvZWyTjZHww=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
## Overview

This PR adds support for go-da v0.4.0. It also uses the new `proxy-grpc` package.

For `GetProofs` to work, the `ID` needs to include the transaction hash. This can be followed up in a different PR.

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved method signatures in `AvailDA` struct for enhanced context management and namespace handling.
	- Transitioned to gRPC for proxy functionality, indicating a shift towards more efficient communication protocols.
- **Tests**
	- Updated test suite to align with the new context parameters and method signature changes, ensuring compatibility and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->